### PR TITLE
Wrap io and parse errors in Peer::receive_message

### DIFF
--- a/src/factories/peer.rs
+++ b/src/factories/peer.rs
@@ -1,6 +1,6 @@
 #![allow(unused_variables)]
 
-use crate::overlay::peer::PeerInterface;
+use crate::overlay::peer::{PeerInterface, MessageReceiveError};
 use crate::scp::local_node::LocalNode;
 use crate::xdr;
 use x25519_dalek::PublicKey;
@@ -36,7 +36,7 @@ impl PeerInterface for PeerMock {
 
     fn receive_message(
         &mut self,
-    ) -> Result<xdr::AuthenticatedMessage, serde_xdr::CompatDeserializationError> {
+    ) -> Result<xdr::AuthenticatedMessage, MessageReceiveError> {
         Ok(xdr::AuthenticatedMessage::default())
     }
 


### PR DESCRIPTION
Resolves #26 (I believe 😅 )

In this PR I wrapped io errors and `serde` parsing errors into one `enum`, it allows to eliminate panics from network errors in `Peer::receive_message` and handle errors consistently