### PR TITLE
Setup CI workflow

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -8,13 +8,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - uses: actions-rs/toolchain@v1
+      - name: Install nightly toolchain
+        uses: actions-rs/toolchain@v1
         with:
           toolchain: nightly-2019-07-15
           override: true
-      - uses: actions-rs/cargo@v1
+      - name: Run cargo check
+        uses: actions-rs/cargo@v1
         with:
           command: check
+          args: --verbose
 
   test:
     name: Test Suite
@@ -28,6 +31,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: test
+          args: --verbose
 
   fmt:
     name: Rustfmt

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,6 +35,7 @@ dependencies = [
  "hmac 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libsqlite3-sys 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-bigint 0.1.44 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -491,6 +492,7 @@ name = "libsqlite3-sys"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
+ "cc 1.0.38 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "vcpkg 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,10 @@ riker-default = "0.2.4"
 ed25519-dalek = "1.0.0-pre.1"
 x25519-dalek = "0.5.2"
 
+[dependencies.libsqlite3-sys]
+version = "*"
+features = ["bundled"]
+
 [profile.dev]
 debug = true
 opt-level = 0

--- a/src/astro_protocol.rs
+++ b/src/astro_protocol.rs
@@ -32,8 +32,6 @@ pub enum AstroProtocol {
     ClearFloodGateCmd(u32),
 }
 
-
-
 impl Into<ActorMsg<AstroProtocol>> for AstroProtocol {
     fn into(self) -> ActorMsg<AstroProtocol> {
         ActorMsg::User(self)

--- a/src/crypto/keypair.rs
+++ b/src/crypto/keypair.rs
@@ -6,8 +6,5 @@ pub fn from_secret_seed(data: &str) -> Result<Keypair> {
     let bytes = strkey::decode_secret_seed(&data)?;
     let secret = SecretKey::from_bytes(&bytes).or(Err(Error::InvalidSeed))?;
     let public = PublicKey::from(&secret);
-    Ok(Keypair {
-        secret,
-        public
-    })
+    Ok(Keypair { secret, public })
 }

--- a/src/factories/peer.rs
+++ b/src/factories/peer.rs
@@ -1,6 +1,6 @@
 #![allow(unused_variables)]
 
-use crate::overlay::peer::{PeerInterface, MessageReceiveError};
+use crate::overlay::peer::{MessageReceiveError, PeerInterface};
 use crate::scp::local_node::LocalNode;
 use crate::xdr;
 use x25519_dalek::PublicKey;
@@ -23,10 +23,7 @@ impl PeerInterface for PeerMock {
     ) {
     }
 
-    fn new_auth_cert(
-        node_info: &LocalNode,
-        auth_public_key: &PublicKey,
-    ) -> xdr::AuthCert {
+    fn new_auth_cert(node_info: &LocalNode, auth_public_key: &PublicKey) -> xdr::AuthCert {
         xdr::AuthCert::default()
     }
 
@@ -34,9 +31,7 @@ impl PeerInterface for PeerMock {
 
     fn send_header(&mut self, message_length: u32) {}
 
-    fn receive_message(
-        &mut self,
-    ) -> Result<xdr::AuthenticatedMessage, MessageReceiveError> {
+    fn receive_message(&mut self) -> Result<xdr::AuthenticatedMessage, MessageReceiveError> {
         Ok(xdr::AuthenticatedMessage::default())
     }
 

--- a/src/network.rs
+++ b/src/network.rs
@@ -1,8 +1,8 @@
 #![allow(dead_code)]
 
-use sha2::Sha256;
-use sha2::digest::Digest;
 use crate::config::CONFIG;
+use sha2::digest::Digest;
+use sha2::Sha256;
 
 /// A Stellar Network.
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/src/overlay/mod.rs
+++ b/src/overlay/mod.rs
@@ -1,7 +1,7 @@
 #![allow(dead_code, unused_must_use)]
 
-use sha2::Sha256;
 use sha2::digest::Digest;
+use sha2::Sha256;
 
 pub(crate) mod flood_gate;
 pub(crate) mod overlay_manager;


### PR DESCRIPTION
- [x] Configure Github Actions workflow  to run `cargo check`, `cargo test`, `cargo fmt` and `cargo clippy` jobs in parallel (clippy is still red, but I think it's ok for now)
- [x] Use sqlite3 bundled with `libsqlite3-sys` crate to simplify the installation
- [x] Fix code formatting to make `rustfmt` happy